### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,4 +7,4 @@ Viceroy
 
 A viceroy is someone who is delegating on behalf authority in a colonized land, in case of this library, viceroy runs Javascript unit tests on behalf of Python for easier testing.
 
-See https://viceroy.readthedocs.org for documentation.
+See https://viceroy.readthedocs.io for documentation.


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.
